### PR TITLE
Fix package build for node apps (#8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@xibosignage/xibo-communication-framework",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Xibo Communication Framework",
-  "main": "dist/xibo-communication-framework.cjs.js",
-  "module": "dist/xibo-communication-framework.esm.js",
-  "typings": "dist/xibo-communication-framework.d.ts",
+  "main": "./dist/xibo-communication-framework.cjs",
+  "module": "./dist/xibo-communication-framework.esm.js",
   "type": "module",
+  "types": "./dist/xibo-communication-framework.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -102,7 +102,7 @@ const config: RollupOptions[] = [
         plugins: [commonInputOptions.plugins],
         output: [
             {
-                file: `${outputPath}${libName}.cjs.js`,
+                file: `${outputPath}${libName}.cjs`,
                 format: 'cjs',
                 sourcemap: true,
                 exports: 'named',


### PR DESCRIPTION
* Fix package build for node apps

* Adjust individual exports for typings

* Remove top-level types field

* Clean up available exports